### PR TITLE
Aspose.Imaging v18.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 		<maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
 		<javadoc.opts>-Xdoclint:none</javadoc.opts>
-		<releaseVersion>18.6</releaseVersion>
+		<releaseVersion>18.8</releaseVersion>
 		<testCategories></testCategories>
     </properties>
     

--- a/src/main/java/com/aspose/imaging/cloud/sdk/api/ImagingApi.java
+++ b/src/main/java/com/aspose/imaging/cloud/sdk/api/ImagingApi.java
@@ -44,7 +44,7 @@ public class ImagingApi
 	/**
 	 * Current SDK version
 	 */
-	public static final String Version = "18.7";
+	public static final String Version = "18.8";
 
 	/**
 	 * The API invoker

--- a/src/test/java/com/aspose/imaging/cloud/test/api/BmpApiTests.java
+++ b/src/test/java/com/aspose/imaging/cloud/test/api/BmpApiTests.java
@@ -66,7 +66,7 @@ public class BmpApiTests extends ApiTester {
         Integer verticalResolution = 300;
         Boolean fromScratch = null;
         String outPath = null;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String storage = TestStorage;
 		String outName = name + "_specific." + "bmp";
 		getImageBmpRequest = new GetImageBmpRequest(name, bitsPerPixel, horizontalResolution, verticalResolution, fromScratch, outPath, folder, storage);
@@ -106,7 +106,7 @@ public class BmpApiTests extends ApiTester {
         Boolean fromScratch = null;
         String outPath = null;
         String storage = TestStorage;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String name = "test.bmp";
 		String outName = name + "_specific." + "bmp";
 		postImageBmpRequest = new PostImageBmpRequest(imageData, bitsPerPixel, horizontalResolution, verticalResolution, fromScratch, outPath, storage);

--- a/src/test/java/com/aspose/imaging/cloud/test/api/CropApiTests.java
+++ b/src/test/java/com/aspose/imaging/cloud/test/api/CropApiTests.java
@@ -74,7 +74,7 @@ public class CropApiTests extends ApiTester {
         Integer width = 100;
         Integer height = 150;
         String outPath = null;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String storage = TestStorage;
 		String outName = null;
 		
@@ -146,7 +146,7 @@ public class CropApiTests extends ApiTester {
         Integer width = 100;
         Integer height = 150;
         String outPath = null;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String storage = TestStorage;
 		String outName = null;
 		
@@ -193,6 +193,56 @@ public class CropApiTests extends ApiTester {
 		            folder,
 		            storage);
             }
+		}
+    }
+    
+    /**
+     * Extended test set for Crop operation.
+     * @throws Exception
+     */
+    @Test
+    public void ExtendedCropTests() throws Exception
+    {
+		if (isExtendedTests())
+    	{
+    		this.getImageCropTest(".bmp", true);
+    		this.getImageCropTest(".bmp", false);
+    		this.postImageCropTest(".bmp", true);
+    		this.postImageCropTest(".bmp", false);
+    		this.getImageCropTest(".dicom", true);
+    		this.getImageCropTest(".dicom", false);
+    		this.postImageCropTest(".dicom", true);
+    		this.postImageCropTest(".dicom", false);
+    		/* TODO: enable after IMAGINGCLOUD-51 is resolved
+    		this.getImageCropTest(".gif", true);
+    		this.getImageCropTest(".gif", false);
+    		this.postImageCropTest(".gif", true);
+    		this.postImageCropTest(".gif", false);
+    		*/
+    		this.getImageCropTest(".j2k", true);
+    		this.getImageCropTest(".j2k", false);
+    		this.postImageCropTest(".j2k", true);
+    		this.postImageCropTest(".j2k", false);
+    		this.getImageCropTest(".png", true);
+    		this.getImageCropTest(".png", false);
+    		this.postImageCropTest(".png", true);
+    		this.postImageCropTest(".png", false);
+    		this.getImageCropTest(".psd", true);
+    		this.getImageCropTest(".psd", false);
+    		this.postImageCropTest(".psd", true);
+    		this.postImageCropTest(".psd", false);
+    		this.getImageCropTest(".tiff", true);
+    		this.getImageCropTest(".tiff", false);
+    		this.postImageCropTest(".tiff", true);
+    		this.postImageCropTest(".tiff", false);
+    		this.getImageCropTest(".webp", true);
+    		this.getImageCropTest(".webp", false);
+    		this.postImageCropTest(".webp", true);
+    		this.postImageCropTest(".webp", false);
+    	}
+		else
+		{
+			System.out.println("Extended tests had been disabled");
 		}
     }
 	

--- a/src/test/java/com/aspose/imaging/cloud/test/api/DicomApiTests.java
+++ b/src/test/java/com/aspose/imaging/cloud/test/api/DicomApiTests.java
@@ -63,7 +63,7 @@ public class DicomApiTests extends ApiTester {
     	String name = "test.dicom";
         Boolean fromScratch = null;
         String outPath = null;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String storage = TestStorage;
 		String outName = name + "_specific." + "png";
 		getImageDicomRequest = new GetImageDicomRequest(name, fromScratch, outPath, folder, storage);
@@ -100,7 +100,7 @@ public class DicomApiTests extends ApiTester {
         Boolean fromScratch = null;
         String outPath = null;
         String storage = TestStorage;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String name = "test.dicom";
 		String outName = name + "_specific." + "png";
 		postImageDicomRequest = new PostImageDicomRequest(imageData, fromScratch, outPath, storage);

--- a/src/test/java/com/aspose/imaging/cloud/test/api/DngApiTests.java
+++ b/src/test/java/com/aspose/imaging/cloud/test/api/DngApiTests.java
@@ -63,7 +63,7 @@ public class DngApiTests extends ApiTester {
     	String name = "test.dng";
         Boolean fromScratch = null;
         String outPath = null;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String storage = TestStorage;
 		String outName = name + "_specific." + "png";
 		getImageDngRequest = new GetImageDngRequest(name, fromScratch, outPath, folder, storage);
@@ -100,7 +100,7 @@ public class DngApiTests extends ApiTester {
         Boolean fromScratch = null;
         String outPath = null;
         String storage = TestStorage;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String name = "test.dng";
 		String outName = name + "_specific." + "png";
 		postImageDngRequest = new PostImageDngRequest(imageData, fromScratch, outPath, storage);

--- a/src/test/java/com/aspose/imaging/cloud/test/api/EmfApiTests.java
+++ b/src/test/java/com/aspose/imaging/cloud/test/api/EmfApiTests.java
@@ -68,7 +68,7 @@ public class EmfApiTests extends ApiTester {
         Integer borderY = 50;
         Boolean fromScratch = null;
         String outPath = null;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String storage = TestStorage;
 		String outName = name + "_specific." + "png";
 		getImageEmfRequest = new GetImageEmfRequest(name, bkColor, pageWidth, pageHeight, borderX, borderY, fromScratch, outPath, folder, storage);
@@ -110,7 +110,7 @@ public class EmfApiTests extends ApiTester {
         Boolean fromScratch = null;
         String outPath = null;
         String storage = TestStorage;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String name = "test.emf";
 		String outName = name + "_specific." + "png";
 		postImageEmfRequest = new PostImageEmfRequest(imageData, bkColor, pageWidth, pageHeight, borderX, borderY, fromScratch, outPath, storage);

--- a/src/test/java/com/aspose/imaging/cloud/test/api/FramesApiTests.java
+++ b/src/test/java/com/aspose/imaging/cloud/test/api/FramesApiTests.java
@@ -70,7 +70,7 @@ public class FramesApiTests extends ApiTester {
         String rotateFlipMethod = "Rotate90FlipX";
         Boolean saveOtherFrames = false;
         String outPath = null;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String storage = TestStorage;
 		String outName = name + "_singleFrame." + "tiff";
 		getImageFrameRequest = new GetImageFrameRequest(name, frameId, newWidth, newHeight, x, y, 
@@ -116,7 +116,7 @@ public class FramesApiTests extends ApiTester {
         String rotateFlipMethod = "Rotate90FlipX";
         Boolean saveOtherFrames = true;
         String outPath = null;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String storage = TestStorage;
 		String outName = name + "_allFrames." + "tiff";
 		getImageFrameRequest = new GetImageFrameRequest(name, frameId, newWidth, newHeight, x, y, 

--- a/src/test/java/com/aspose/imaging/cloud/test/api/GifApiTests.java
+++ b/src/test/java/com/aspose/imaging/cloud/test/api/GifApiTests.java
@@ -69,7 +69,7 @@ public class GifApiTests extends ApiTester {
         Integer pixelAspectRatio = 4;
         Boolean fromScratch = null;
         String outPath = null;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String storage = TestStorage;
 		String outName = name + "_specific." + "gif";
 		getImageGifRequest = new GetImageGifRequest(name, backgroundColorIndex, colorResolution, hasTrailer, interlaced, isPaletteSorted, 
@@ -114,7 +114,7 @@ public class GifApiTests extends ApiTester {
         Boolean fromScratch = null;
         String outPath = null;
         String storage = TestStorage;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String name = "test.gif";
 		String outName = name + "_specific." + "gif";
 		postImageGifRequest = new PostImageGifRequest(imageData, backgroundColorIndex, colorResolution, hasTrailer, interlaced, isPaletteSorted, 

--- a/src/test/java/com/aspose/imaging/cloud/test/api/Jpeg2000ApiTests.java
+++ b/src/test/java/com/aspose/imaging/cloud/test/api/Jpeg2000ApiTests.java
@@ -65,7 +65,7 @@ public class Jpeg2000ApiTests extends ApiTester {
         String comment = "Aspose";
         Boolean fromScratch = null;
         String outPath = null;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String storage = TestStorage;
 		String outName = name + "_specific." + "jp2";
 		getImageJpeg2000Request = new GetImageJpeg2000Request(name, comment, codec, fromScratch, outPath, folder, storage);
@@ -104,7 +104,7 @@ public class Jpeg2000ApiTests extends ApiTester {
         Boolean fromScratch = null;
         String outPath = null;
         String storage = TestStorage;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String name = "test.j2k";
 		String outName = name + "_specific." + "jp2";
 		postImageJpeg2000Request = new PostImageJpeg2000Request(imageData, comment, codec, fromScratch, outPath, storage);

--- a/src/test/java/com/aspose/imaging/cloud/test/api/JpgApiTests.java
+++ b/src/test/java/com/aspose/imaging/cloud/test/api/JpgApiTests.java
@@ -65,7 +65,7 @@ public class JpgApiTests extends ApiTester {
         String compressionType = "progressive";
         Boolean fromScratch = null;
         String outPath = null;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String storage = TestStorage;
 		String outName = name + "_specific." + "jpg";
 		getImageJpgRequest = new GetImageJpgRequest(name, quality, compressionType, fromScratch, outPath, folder, storage);
@@ -104,7 +104,7 @@ public class JpgApiTests extends ApiTester {
         Boolean fromScratch = null;
         String outPath = null;
         String storage = TestStorage;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String name = "test.jpg";
 		String outName = name + "_specific." + "jpg";
 		postImageJpgRequest = new PostImageJpgRequest(imageData, quality, compressionType, fromScratch, outPath, storage);

--- a/src/test/java/com/aspose/imaging/cloud/test/api/OdgApiTests.java
+++ b/src/test/java/com/aspose/imaging/cloud/test/api/OdgApiTests.java
@@ -63,7 +63,7 @@ public class OdgApiTests extends ApiTester {
     	String name = "test.odg";
         Boolean fromScratch = null;
         String outPath = null;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String storage = TestStorage;
 		String outName = name + "_specific." + "png";
 		getImageOdgRequest = new GetImageOdgRequest(name, fromScratch, outPath, folder, storage);
@@ -100,7 +100,7 @@ public class OdgApiTests extends ApiTester {
         Boolean fromScratch = null;
         String outPath = null;
         String storage = TestStorage;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String name = "test.odg";
 		String outName = name + "_specific." + "png";
 		postImageOdgRequest = new PostImageOdgRequest(imageData, fromScratch, outPath, storage);

--- a/src/test/java/com/aspose/imaging/cloud/test/api/PngApiTests.java
+++ b/src/test/java/com/aspose/imaging/cloud/test/api/PngApiTests.java
@@ -63,7 +63,7 @@ public class PngApiTests extends ApiTester {
     	String name = "test.png";
         Boolean fromScratch = false;
         String outPath = null;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String storage = TestStorage;
 		String outName = name + "_specific." + "png";
 		getImagePngRequest = new GetImagePngRequest(name, fromScratch, outPath, folder, storage);
@@ -100,7 +100,7 @@ public class PngApiTests extends ApiTester {
         Boolean fromScratch = false;
         String outPath = null;
         String storage = TestStorage;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String name = "test.png";
 		String outName = name + "_specific." + "png";
 		postImagePngRequest = new PostImagePngRequest(imageData, fromScratch, outPath, storage);

--- a/src/test/java/com/aspose/imaging/cloud/test/api/PsdApiTests.java
+++ b/src/test/java/com/aspose/imaging/cloud/test/api/PsdApiTests.java
@@ -65,7 +65,7 @@ public class PsdApiTests extends ApiTester {
         String compressionMethod = "raw";
         Boolean fromScratch = null;
         String outPath = null;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String storage = TestStorage;
 		String outName = name + "_specific." + "psd";
 		getImagePsdRequest = new GetImagePsdRequest(name, channelsCount, compressionMethod, fromScratch, outPath, folder, storage);
@@ -104,7 +104,7 @@ public class PsdApiTests extends ApiTester {
         Boolean fromScratch = null;
         String outPath = null;
         String storage = TestStorage;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String name = "test.psd";
 		String outName = name + "_specific." + "psd";
 		postImagePsdRequest = new PostImagePsdRequest(imageData, channelsCount, compressionMethod, fromScratch, outPath, storage);

--- a/src/test/java/com/aspose/imaging/cloud/test/api/ResizeApiTests.java
+++ b/src/test/java/com/aspose/imaging/cloud/test/api/ResizeApiTests.java
@@ -44,7 +44,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 
 /**
- * Class for testing crop-related API calls
+ * Class for testing Resize-related API calls
  */
 @Category(ResizeTestCategory.class)
 @RunWith(JUnitParamsRunner.class)
@@ -72,7 +72,7 @@ public class ResizeApiTests extends ApiTester {
         Integer newWidth = 100;
         Integer newHeight = 150;
         String outPath = null;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String storage = TestStorage;
 		String outName = null;
 		
@@ -142,7 +142,7 @@ public class ResizeApiTests extends ApiTester {
 		Integer newWidth = 100;
         Integer newHeight = 150;
         String outPath = null;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String storage = TestStorage;
 		String outName = null;
 		
@@ -189,6 +189,56 @@ public class ResizeApiTests extends ApiTester {
 		            folder,
 		            storage);
             }
+		}
+    }
+    
+    /**
+     * Extended test set for Resize operation.
+     * @throws Exception
+     */
+    @Test
+    public void ExtendedResizeTests() throws Exception
+    {
+		if (isExtendedTests())
+    	{
+    		this.getImageResizeTest(".bmp", true);
+    		this.getImageResizeTest(".bmp", false);
+    		this.postImageResizeTest(".bmp", true);
+    		this.postImageResizeTest(".bmp", false);
+    		this.getImageResizeTest(".dicom", true);
+    		this.getImageResizeTest(".dicom", false);
+    		this.postImageResizeTest(".dicom", true);
+    		this.postImageResizeTest(".dicom", false);
+    		/* TODO: enable after IMAGINGCLOUD-51 is resolved
+    		this.getImageResizeTest(".gif", true);
+    		this.getImageResizeTest(".gif", false);
+    		this.postImageResizeTest(".gif", true);
+    		this.postImageResizeTest(".gif", false);
+    		*/
+    		this.getImageResizeTest(".j2k", true);
+    		this.getImageResizeTest(".j2k", false);
+    		this.postImageResizeTest(".j2k", true);
+    		this.postImageResizeTest(".j2k", false);
+    		this.getImageResizeTest(".png", true);
+    		this.getImageResizeTest(".png", false);
+    		this.postImageResizeTest(".png", true);
+    		this.postImageResizeTest(".png", false);
+    		this.getImageResizeTest(".psd", true);
+    		this.getImageResizeTest(".psd", false);
+    		this.postImageResizeTest(".psd", true);
+    		this.postImageResizeTest(".psd", false);
+    		this.getImageResizeTest(".tiff", true);
+    		this.getImageResizeTest(".tiff", false);
+    		this.postImageResizeTest(".tiff", true);
+    		this.postImageResizeTest(".tiff", false);
+    		this.getImageResizeTest(".webp", true);
+    		this.getImageResizeTest(".webp", false);
+    		this.postImageResizeTest(".webp", true);
+    		this.postImageResizeTest(".webp", false);
+    	}
+		else
+		{
+			System.out.println("Extended tests had been disabled");
 		}
     }
 	

--- a/src/test/java/com/aspose/imaging/cloud/test/api/RotateFlipApiTests.java
+++ b/src/test/java/com/aspose/imaging/cloud/test/api/RotateFlipApiTests.java
@@ -72,7 +72,7 @@ public class RotateFlipApiTests extends ApiTester {
         String name = null;
         String method = "Rotate90FlipX";
         String outPath = null;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String storage = TestStorage;
 		String outName = null;
 		
@@ -141,7 +141,7 @@ public class RotateFlipApiTests extends ApiTester {
 		String name = null;
 		String method = "Rotate90FlipX";
         String outPath = null;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String storage = TestStorage;
 		String outName = null;
 		
@@ -188,6 +188,56 @@ public class RotateFlipApiTests extends ApiTester {
 		            folder,
 		            storage);
             }
+		}
+    }
+    
+    /**
+     * Extended test set for RotateFlip operation.
+     * @throws Exception
+     */
+    @Test
+    public void ExtendedRotateFlipTests() throws Exception
+    {
+		if (isExtendedTests())
+    	{
+    		this.getImageRotateFlipTest(".bmp", true);
+    		this.getImageRotateFlipTest(".bmp", false);
+    		this.postImageRotateFlipTest(".bmp", true);
+    		this.postImageRotateFlipTest(".bmp", false);
+    		this.getImageRotateFlipTest(".dicom", true);
+    		this.getImageRotateFlipTest(".dicom", false);
+    		this.postImageRotateFlipTest(".dicom", true);
+    		this.postImageRotateFlipTest(".dicom", false);
+    		/* TODO: enable after IMAGINGCLOUD-51 is resolved
+    		this.getImageRotateFlipTest(".gif", true);
+    		this.getImageRotateFlipTest(".gif", false);
+    		this.postImageRotateFlipTest(".gif", true);
+    		this.postImageRotateFlipTest(".gif", false);
+    		*/
+    		this.getImageRotateFlipTest(".j2k", true);
+    		this.getImageRotateFlipTest(".j2k", false);
+    		this.postImageRotateFlipTest(".j2k", true);
+    		this.postImageRotateFlipTest(".j2k", false);
+    		this.getImageRotateFlipTest(".png", true);
+    		this.getImageRotateFlipTest(".png", false);
+    		this.postImageRotateFlipTest(".png", true);
+    		this.postImageRotateFlipTest(".png", false);
+    		this.getImageRotateFlipTest(".psd", true);
+    		this.getImageRotateFlipTest(".psd", false);
+    		this.postImageRotateFlipTest(".psd", true);
+    		this.postImageRotateFlipTest(".psd", false);
+    		this.getImageRotateFlipTest(".tiff", true);
+    		this.getImageRotateFlipTest(".tiff", false);
+    		this.postImageRotateFlipTest(".tiff", true);
+    		this.postImageRotateFlipTest(".tiff", false);
+    		this.getImageRotateFlipTest(".webp", true);
+    		this.getImageRotateFlipTest(".webp", false);
+    		this.postImageRotateFlipTest(".webp", true);
+    		this.postImageRotateFlipTest(".webp", false);
+    	}
+		else
+		{
+			System.out.println("Extended tests had been disabled");
 		}
     }
 	

--- a/src/test/java/com/aspose/imaging/cloud/test/api/SaveAsApiTests.java
+++ b/src/test/java/com/aspose/imaging/cloud/test/api/SaveAsApiTests.java
@@ -69,7 +69,7 @@ public class SaveAsApiTests extends ApiTester {
     public void getImageSaveAsTest(String formatExtension, Boolean saveResultToStorage, String... additionalExportFormats) throws Exception {
         String name = null;
         String outPath = null;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String storage = TestStorage;
 		String outName = null;
 		
@@ -137,7 +137,7 @@ public class SaveAsApiTests extends ApiTester {
     	byte[] imageData = null;
 		String name = null;
         String outPath = null;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String storage = TestStorage;
 		String outName = null;
 		
@@ -184,6 +184,56 @@ public class SaveAsApiTests extends ApiTester {
 		            folder,
 		            storage);
             }
+		}
+    }
+    
+    /**
+     * Extended test set for SaveAs operation.
+     * @throws Exception
+     */
+    @Test
+    public void ExtendedSaveAsTests() throws Exception
+    {
+		if (isExtendedTests())
+    	{
+    		this.getImageSaveAsTest(".bmp", true);
+    		this.getImageSaveAsTest(".bmp", false);
+    		this.postImageSaveAsTest(".bmp", true);
+    		this.postImageSaveAsTest(".bmp", false);
+    		this.getImageSaveAsTest(".dicom", true);
+    		this.getImageSaveAsTest(".dicom", false);
+    		this.postImageSaveAsTest(".dicom", true);
+    		this.postImageSaveAsTest(".dicom", false);
+    		/* TODO: enable after IMAGINGCLOUD-51 is resolved
+    		this.getImageSaveAsTest(".gif", true);
+    		this.getImageSaveAsTest(".gif", false);
+    		this.postImageSaveAsTest(".gif", true);
+    		this.postImageSaveAsTest(".gif", false);
+    		*/
+    		this.getImageSaveAsTest(".j2k", true);
+    		this.getImageSaveAsTest(".j2k", false);
+    		this.postImageSaveAsTest(".j2k", true);
+    		this.postImageSaveAsTest(".j2k", false);
+    		this.getImageSaveAsTest(".png", true);
+    		this.getImageSaveAsTest(".png", false);
+    		this.postImageSaveAsTest(".png", true);
+    		this.postImageSaveAsTest(".png", false);
+    		this.getImageSaveAsTest(".psd", true);
+    		this.getImageSaveAsTest(".psd", false);
+    		this.postImageSaveAsTest(".psd", true);
+    		this.postImageSaveAsTest(".psd", false);
+    		this.getImageSaveAsTest(".tiff", true);
+    		this.getImageSaveAsTest(".tiff", false);
+    		this.postImageSaveAsTest(".tiff", true);
+    		this.postImageSaveAsTest(".tiff", false);
+    		this.getImageSaveAsTest(".webp", true);
+    		this.getImageSaveAsTest(".webp", false);
+    		this.postImageSaveAsTest(".webp", true);
+    		this.postImageSaveAsTest(".webp", false);
+    	}
+		else
+		{
+			System.out.println("Extended tests had been disabled");
 		}
     }
 	

--- a/src/test/java/com/aspose/imaging/cloud/test/api/TiffApiTests.java
+++ b/src/test/java/com/aspose/imaging/cloud/test/api/TiffApiTests.java
@@ -76,7 +76,7 @@ public class TiffApiTests extends ApiTester {
         double verticalResolution = 150;
         Boolean fromScratch = null;
         String outPath = null;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String storage = TestStorage;
 		String outName = name + "_specific." + "tiff";
 		getImageTiffRequest = new GetImageTiffRequest(name, compression, resolutionUnit, bitDepth, fromScratch, 
@@ -119,7 +119,7 @@ public class TiffApiTests extends ApiTester {
         Boolean fromScratch = null;
         String outPath = null;
         String storage = TestStorage;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String name = "test.tiff";
 		String outName = name + "_specific." + "tiff";
 		postImageTiffRequest = new PostImageTiffRequest(imageData, compression, resolutionUnit, bitDepth, fromScratch, 
@@ -153,7 +153,7 @@ public class TiffApiTests extends ApiTester {
     public void getTiffToFaxTest() throws Exception {
     	String name = "test.tiff";
         String outPath = null;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String storage = TestStorage;
 		String outName = name + "_fax." + "tiff";
 		getTiffToFaxRequest = new GetTiffToFaxRequest(name, storage, folder, outPath);
@@ -188,7 +188,7 @@ public class TiffApiTests extends ApiTester {
         System.out.println("Test method: postTiffAppendTest");
 
         String inputFileName = "test.tiff";
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
 
         if (!checkInputFileExists(inputFileName))
         {
@@ -199,7 +199,7 @@ public class TiffApiTests extends ApiTester {
 
         String resultFileName = inputFileName + "_merged.tiff";
         String outPath = null;
-        String inputPath = CloudTestFolder + "/" + inputFileName;
+        String inputPath = TempFolder + "/" + inputFileName;
         String storage = TestStorage;
         String referencePath = CloudReferencesFolder + "/Tiff";
 
@@ -282,7 +282,7 @@ public class TiffApiTests extends ApiTester {
         }
         finally
         {
-            if (this.RemoveResult && StorageApi.GetIsExist(outPath, "", storage).getFileExist().getIsExist())
+            if (RemoveResult && StorageApi.GetIsExist(outPath, "", storage).getFileExist().getIsExist())
             {
                 StorageApi.DeleteFile(outPath, "", storage);
             }

--- a/src/test/java/com/aspose/imaging/cloud/test/api/UpdateImageApiTests.java
+++ b/src/test/java/com/aspose/imaging/cloud/test/api/UpdateImageApiTests.java
@@ -77,7 +77,7 @@ public class UpdateImageApiTests extends ApiTester {
         Integer rectWidth = 200;
         Integer rectHeight = 300;
         String rotateFlipMethod = "Rotate90FlipX";
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String storage = TestStorage;
 		String outName = null;
 		
@@ -153,7 +153,7 @@ public class UpdateImageApiTests extends ApiTester {
         Integer rectWidth = 200;
         Integer rectHeight = 300;
         String rotateFlipMethod = "Rotate90FlipX";
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String storage = TestStorage;
 		String outName = null;
 		
@@ -202,6 +202,56 @@ public class UpdateImageApiTests extends ApiTester {
 		            folder,
 		            storage);
             }
+		}
+    }
+    
+    /**
+     * Extended test set for Update operation.
+     * @throws Exception
+     */
+    @Test
+    public void ExtendedUpdateTests() throws Exception
+    {
+		if (isExtendedTests())
+    	{
+    		this.getImageUpdateTest(".bmp", true);
+    		this.getImageUpdateTest(".bmp", false);
+    		this.postImageUpdateTest(".bmp", true);
+    		this.postImageUpdateTest(".bmp", false);
+    		this.getImageUpdateTest(".dicom", true);
+    		this.getImageUpdateTest(".dicom", false);
+    		this.postImageUpdateTest(".dicom", true);
+    		this.postImageUpdateTest(".dicom", false);
+    		/* TODO: enable after IMAGINGCLOUD-51 is resolved
+    		this.getImageUpdateTest(".gif", true);
+    		this.getImageUpdateTest(".gif", false);
+    		this.postImageUpdateTest(".gif", true);
+    		this.postImageUpdateTest(".gif", false);
+    		*/
+    		this.getImageUpdateTest(".j2k", true);
+    		this.getImageUpdateTest(".j2k", false);
+    		this.postImageUpdateTest(".j2k", true);
+    		this.postImageUpdateTest(".j2k", false);
+    		this.getImageUpdateTest(".png", true);
+    		this.getImageUpdateTest(".png", false);
+    		this.postImageUpdateTest(".png", true);
+    		this.postImageUpdateTest(".png", false);
+    		this.getImageUpdateTest(".psd", true);
+    		this.getImageUpdateTest(".psd", false);
+    		this.postImageUpdateTest(".psd", true);
+    		this.postImageUpdateTest(".psd", false);
+    		this.getImageUpdateTest(".tiff", true);
+    		this.getImageUpdateTest(".tiff", false);
+    		this.postImageUpdateTest(".tiff", true);
+    		this.postImageUpdateTest(".tiff", false);
+    		this.getImageUpdateTest(".webp", true);
+    		this.getImageUpdateTest(".webp", false);
+    		this.postImageUpdateTest(".webp", true);
+    		this.postImageUpdateTest(".webp", false);
+    	}
+		else
+		{
+			System.out.println("Extended tests had been disabled");
 		}
     }
 	

--- a/src/test/java/com/aspose/imaging/cloud/test/api/WebpApiTests.java
+++ b/src/test/java/com/aspose/imaging/cloud/test/api/WebpApiTests.java
@@ -68,7 +68,7 @@ public class WebpApiTests extends ApiTester {
         String animBackgroundColor = "gray";
         Boolean fromScratch = null;
         String outPath = null;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String storage = TestStorage;
 		String outName = name + "_specific." + "webp";
 		getImageWebPRequest = new GetImageWebPRequest(name, lossless, quality, animLoopCount, animBackgroundColor, fromScratch, outPath, folder, storage);
@@ -109,7 +109,7 @@ public class WebpApiTests extends ApiTester {
         Boolean fromScratch = null;
         String outPath = null;
         String storage = TestStorage;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String name = "Animation.webp";
 		String outName = name + "_specific." + "webp";
 		postImageWebPRequest = new PostImageWebPRequest(imageData, lossless, quality, animLoopCount, animBackgroundColor, fromScratch, outPath, storage);

--- a/src/test/java/com/aspose/imaging/cloud/test/api/WmfApiTests.java
+++ b/src/test/java/com/aspose/imaging/cloud/test/api/WmfApiTests.java
@@ -68,7 +68,7 @@ public class WmfApiTests extends ApiTester {
         Integer borderY = 50;
         Boolean fromScratch = null;
         String outPath = null;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String storage = TestStorage;
 		String outName = name + "_specific." + "png";
 		getImageWmfRequest = new GetImageWmfRequest(name, bkColor, pageWidth, pageHeight, borderX, borderY, fromScratch, outPath, folder, storage);
@@ -110,7 +110,7 @@ public class WmfApiTests extends ApiTester {
         Boolean fromScratch = null;
         String outPath = null;
         String storage = TestStorage;
-        String folder = CloudTestFolder;
+        String folder = TempFolder;
         String name = "test.wmf";
 		String outName = name + "_specific." + "png";
 		postImageWmfRequest = new PostImageWmfRequest(imageData, bkColor, pageWidth, pageHeight, borderX, borderY, fromScratch, outPath, storage);

--- a/src/test/java/com/aspose/imaging/cloud/test/api/ai/TestImagingAIBase.java
+++ b/src/test/java/com/aspose/imaging/cloud/test/api/ai/TestImagingAIBase.java
@@ -31,11 +31,9 @@ import com.aspose.imaging.cloud.sdk.invoker.ApiResponse;
 import com.aspose.imaging.cloud.sdk.model.SearchContextStatus;
 import com.aspose.imaging.cloud.sdk.model.requests.*;
 import com.aspose.imaging.cloud.test.base.ApiTester;
-import com.aspose.imaging.cloud.test.categories.AITestCategory;
 
 import org.apache.commons.lang.StringUtils;
 import org.junit.*;
-import org.junit.experimental.categories.Category;
 
 public abstract class TestImagingAIBase extends ApiTester {
 
@@ -59,9 +57,9 @@ public abstract class TestImagingAIBase extends ApiTester {
 
 	protected String SearchContextId;
 
-	protected final static String OriginalDataFolder = "ImagingAI";
+	protected final static String OriginalDataFolder = "ImagingAiSdk";
 
-	protected final static String TempFolder = "TempImagingAI";
+	protected final static String TempFolder = "ImagingAICloudTestJava_" + getTempFolderId();
 
 	protected static String getStoragePath(String imageName, String folder) {
 		return (folder != null ? folder : OriginalDataFolder) + "/" + imageName;


### PR DESCRIPTION
Updated version, add extended test set support, added dynamic temp folders generation to be able to run the same SDK sets in parallel, added Fallback test folder processing, changed AI folder not to conflict with Platform.